### PR TITLE
fixes a value error of `source`

### DIFF
--- a/search.js
+++ b/search.js
@@ -445,7 +445,7 @@ $.fn.search = function(parameters) {
             source = source || settings.source;
 
             // exit conditions on no source
-            if(source === undefined) {
+            if(source === undefined || source === false) {
               module.error(error.source);
               return [];
             }


### PR DESCRIPTION
The default value of `$.fn.search.settings.source` is `false`, and the default value of `source` is `undefined`

so,  `source = source || settings.source` :  

the value of 'source' is `false`

 this cause error when exec `$.each(source)`
